### PR TITLE
Adding Gnome 41

### DIFF
--- a/stocks@infinicode.de/metadata.json
+++ b/stocks@infinicode.de/metadata.json
@@ -8,7 +8,8 @@
     "3.34",
     "3.36",
     "3.38",
-    "40"
+    "40",
+    "41"
   ],
   "url": "https://github.com/cinatic/stocks-extension",
   "uuid": "stocks@infinicode.de",


### PR DESCRIPTION
Adding Gnome 41 to the metadata targets (I think this will get the extension to work with Gnome 41?)