### PR TITLE
Add customizable quote styles

### DIFF
--- a/stocks@infinicode.de/components/cards/newsCard.js
+++ b/stocks@infinicode.de/components/cards/newsCard.js
@@ -3,14 +3,14 @@ const { Clutter, GObject, Pango, St } = imports.gi
 const ExtensionUtils = imports.misc.extensionUtils
 const Me = ExtensionUtils.getCurrentExtension()
 
-const { fallbackIfNaN, roundOrDefault, getStockColorStyleClass } = Me.imports.helpers.data
+const { fallbackIfNaN, roundOrDefault } = Me.imports.helpers.data
 const { Translations } = Me.imports.helpers.translations
 const { MARKET_STATES } = Me.imports.services.meta.generic
 
 var NewsCard = GObject.registerClass({
   GTypeName: 'StockExtension_NewsCard'
 }, class NewsCard extends St.Button {
-  _init (newsItem, fgColor) {
+  _init(newsItem, fgColor) {
     super._init({
       style_class: 'card message news-card',
       can_focus: true,
@@ -34,7 +34,7 @@ var NewsCard = GObject.registerClass({
     this._sync()
   }
 
-  _createNewsContent () {
+  _createNewsContent() {
     let newsContentBox = new St.BoxLayout({
       style_class: 'news-content-box',
       x_expand: true,
@@ -83,9 +83,9 @@ var NewsCard = GObject.registerClass({
     return newsContentBox
   }
 
-  _sync () {
+  _sync() {
   }
 
-  _onDestroy () {
+  _onDestroy() {
   }
 })

--- a/stocks@infinicode.de/components/cards/stockCard.js
+++ b/stocks@infinicode.de/components/cards/stockCard.js
@@ -3,14 +3,15 @@ const { Clutter, GObject, Pango, St } = imports.gi
 const ExtensionUtils = imports.misc.extensionUtils
 const Me = ExtensionUtils.getCurrentExtension()
 
-const { fallbackIfNaN, roundOrDefault, getStockColorStyleClass } = Me.imports.helpers.data
+const { fallbackIfNaN, roundOrDefault } = Me.imports.helpers.data
 const { Translations } = Me.imports.helpers.translations
 const { MARKET_STATES } = Me.imports.services.meta.generic
+const { getQuoteStyle } = Me.imports.helpers.styles
 
 var StockCard = GObject.registerClass({
   GTypeName: 'StockExtension_StockCard'
 }, class StockCard extends St.Button {
-  _init (quoteSummary) {
+  _init(quoteSummary) {
     super._init({
       style_class: 'card message stock-card',
       can_focus: true,
@@ -33,7 +34,7 @@ var StockCard = GObject.registerClass({
     this._sync()
   }
 
-  _createCardHeader () {
+  _createCardHeader() {
     const headerBox = new St.BoxLayout({
       style_class: 'header-box',
       x_expand: true,
@@ -49,7 +50,7 @@ var StockCard = GObject.registerClass({
     return headerBox
   }
 
-  _createStockInfo () {
+  _createStockInfo() {
     let stockInformationBox = new St.BoxLayout({
       style_class: 'stock-information-box',
       x_expand: true,
@@ -78,7 +79,7 @@ var StockCard = GObject.registerClass({
     return stockInformationBox
   }
 
-  _createQuoteInfo () {
+  _createQuoteInfo() {
     const quoteInformationBox = new St.BoxLayout({
       style_class: 'quote-information-box',
       vertical: true
@@ -89,20 +90,22 @@ var StockCard = GObject.registerClass({
       x_align: Clutter.ActorAlign.END
     })
 
-    const quoteColorStyleClass = getStockColorStyleClass(this.cardItem.Change)
+    const quoteStyle = getQuoteStyle(this.cardItem.Change)
 
     const regularQuoteLabel = new St.Label({
-      style_class: `quote-label ${quoteColorStyleClass}`,
+      style_class: `quote-label`,
+      style: quoteStyle,
       text: `${roundOrDefault(this.cardItem.Close)}${this.cardItem.CurrencySymbol ? ` ${this.cardItem.CurrencySymbol}` : ''}`
     })
 
     quoteInformationPriceBox.add_child(regularQuoteLabel)
 
     if (this.cardItem.MarketState === MARKET_STATES.PRE) {
-      const preMarketQuoteColorStyleClass = getStockColorStyleClass(this.cardItem.PreMarketChange)
+      const preMarketQuoteStyle = getQuoteStyle(this.cardItem.PreMarketChange)
 
       const preMarketQuoteLabel = new St.Label({
-        style_class: `quote-label pre-market ${preMarketQuoteColorStyleClass}`,
+        style_class: `quote-label pre-market`,
+        style: preMarketQuoteStyle,
         text: `${roundOrDefault(this.cardItem.PreMarketPrice)}${this.cardItem.CurrencySymbol ? ` ${this.cardItem.CurrencySymbol}` : ''}*`
       })
 
@@ -111,10 +114,11 @@ var StockCard = GObject.registerClass({
     }
 
     if (this.cardItem.MarketState === MARKET_STATES.POST) {
-      const postMarketQuoteColorStyleClass = getStockColorStyleClass(this.cardItem.PostMarketChange)
+      const postMarketQuoteStyle = getQuoteStyle(this.cardItem.PostMarketChange)
 
       const postMarketQuoteLabel = new St.Label({
-        style_class: `quote-label post-market ${postMarketQuoteColorStyleClass}`,
+        style_class: `quote-label post-market`,
+        style: postMarketQuoteStyle,
         text: `${roundOrDefault(this.cardItem.PostMarketPrice)}${this.cardItem.CurrencySymbol ? ` ${this.cardItem.CurrencySymbol}` : ''}*`
       })
 
@@ -138,8 +142,8 @@ var StockCard = GObject.registerClass({
     return quoteInformationBox
   }
 
-  _createRegularAdditionalInformationBox () {
-    const quoteColorStyleClass = getStockColorStyleClass(this.cardItem.Change)
+  _createRegularAdditionalInformationBox() {
+    const quoteStyle = getQuoteStyle(this.cardItem.Change)
 
     const additionalInformationBox = new St.BoxLayout({
       style_class: 'info-section-box tar',
@@ -147,12 +151,14 @@ var StockCard = GObject.registerClass({
     })
 
     const quoteChangeLabel = new St.Label({
-      style_class: `small-text fwb ${quoteColorStyleClass}`,
+      style_class: `small-text fwb`,
+      style: quoteStyle,
       text: `${roundOrDefault(this.cardItem.Change)}${this.cardItem.CurrencySymbol ? ` ${this.cardItem.CurrencySymbol}` : ''}`
     })
 
     const quoteChangePercentLabel = new St.Label({
-      style_class: `small-text fwb ${quoteColorStyleClass}`,
+      style_class: `small-text fwb`,
+      style: quoteStyle,
       text: `${roundOrDefault(this.cardItem.ChangePercent)} %`
     })
 
@@ -176,8 +182,8 @@ var StockCard = GObject.registerClass({
     return additionalInformationBox
   }
 
-  _createPreMarketAdditionalInformationBox () {
-    const quoteColorStyleClass = getStockColorStyleClass(this.cardItem.PreMarketChange)
+  _createPreMarketAdditionalInformationBox() {
+    const quoteStyle = getQuoteStyle(this.cardItem.PreMarketChange)
 
     const additionalInformationBox = new St.BoxLayout({
       style_class: 'info-section-box tar',
@@ -185,12 +191,14 @@ var StockCard = GObject.registerClass({
     })
 
     const quoteChangeLabel = new St.Label({
-      style_class: `small-text fwb ${quoteColorStyleClass}`,
+      style_class: `small-text fwb`,
+      style: quoteStyle,
       text: `${roundOrDefault(this.cardItem.PreMarketChange)}${this.cardItem.CurrencySymbol ? ` ${this.cardItem.CurrencySymbol}` : ''}`
     })
 
     const quoteChangePercentLabel = new St.Label({
-      style_class: `small-text fwb ${quoteColorStyleClass}`,
+      style_class: `small-text fwb`,
+      style: quoteStyle,
       text: `${roundOrDefault(this.cardItem.PreMarketChangePercent)} %`
     })
 
@@ -214,8 +222,8 @@ var StockCard = GObject.registerClass({
     return additionalInformationBox
   }
 
-  _createPostMarketAdditionalInformationBox () {
-    const quoteColorStyleClass = getStockColorStyleClass(this.cardItem.PostMarketChange)
+  _createPostMarketAdditionalInformationBox() {
+    const quoteStyle = getQuoteStyle(this.cardItem.PostMarketChange)
 
     const additionalInformationBox = new St.BoxLayout({
       style_class: 'info-section-box tar',
@@ -223,12 +231,14 @@ var StockCard = GObject.registerClass({
     })
 
     const quoteChangeLabel = new St.Label({
-      style_class: `small-text fwb ${quoteColorStyleClass}`,
+      style_class: `small-text fwb`,
+      style: quoteStyle,
       text: `${roundOrDefault(this.cardItem.PostMarketChange)}${this.cardItem.CurrencySymbol ? ` ${this.cardItem.CurrencySymbol}` : ''}`
     })
 
     const quoteChangePercentLabel = new St.Label({
-      style_class: `small-text fwb ${quoteColorStyleClass}`,
+      style_class: `small-text fwb`,
+      style: quoteStyle,
       text: `${roundOrDefault(this.cardItem.PostMarketChangePercent)} %`
     })
 
@@ -252,9 +262,9 @@ var StockCard = GObject.registerClass({
     return additionalInformationBox
   }
 
-  _sync () {
+  _sync() {
   }
 
-  _onDestroy () {
+  _onDestroy() {
   }
 })

--- a/stocks@infinicode.de/components/screens/stockDetailsScreen/stockDetailsScreen.js
+++ b/stocks@infinicode.de/components/screens/stockDetailsScreen/stockDetailsScreen.js
@@ -8,16 +8,17 @@ const { Chart } = Me.imports.components.chart.chart
 const { StockDetails } = Me.imports.components.stocks.stockDetails
 const { SearchBar } = Me.imports.components.searchBar.searchBar
 
-const { clearCache, roundOrDefault, getStockColorStyleClass } = Me.imports.helpers.data
+const { clearCache, roundOrDefault } = Me.imports.helpers.data
 const { Translations } = Me.imports.helpers.translations
 
 const { CHART_RANGES, CHART_RANGES_MAX_GAP } = Me.imports.services.meta.generic
 const FinanceService = Me.imports.services.financeService
+const { getQuoteStyle } = Me.imports.helpers.styles
 
 var StockDetailsScreen = GObject.registerClass({
   GTypeName: 'StockExtension_StockDetailsScreen'
 }, class StockDetailsScreen extends St.BoxLayout {
-  _init ({ quoteSummary, mainEventHandler }) {
+  _init({ quoteSummary, mainEventHandler }) {
     super._init({
       style_class: 'screen stock-details-screen',
       vertical: true
@@ -32,7 +33,7 @@ var StockDetailsScreen = GObject.registerClass({
     this._sync()
   }
 
-  async _sync () {
+  async _sync() {
     const [quoteSummary, quoteHistorical] = await Promise.all([
       FinanceService.getQuoteSummary({
         symbol: this._passedQuoteSummary.Symbol,
@@ -141,11 +142,12 @@ var StockDetailsScreen = GObject.registerClass({
       const changeAbsolute = roundOrDefault(this._quoteSummary.Close - y)
       const changePercentage = roundOrDefault((this._quoteSummary.Close / y * 100) - 100)
 
-      const changeColorStyleClass = getStockColorStyleClass(changePercentage)
+      const quoteStyle = getQuoteStyle(changePercentage)
 
       chartValueLabel.text = `${(new Date(x)).toLocaleFormat(Translations.FORMATS.DEFAULT_DATE_TIME)} ${roundOrDefault(y)}`
       chartValueChangeLabel.text = `(${changeAbsolute} / ${changePercentage} %)`
-      chartValueChangeLabel.style_class = `chart-hover-change-label ${changeColorStyleClass}`
+      chartValueChangeLabel.style_class = `chart-hover-change-label`
+      chartValueChangeLabel.style = quoteStyle
     })
 
     this.add_child(searchBar)
@@ -159,7 +161,7 @@ var StockDetailsScreen = GObject.registerClass({
     this.add_child(chartValueHoverBox)
   }
 
-  _onChartDraw ({ width, height, cairoContext, secondaryColor }) {
+  _onChartDraw({ width, height, cairoContext, secondaryColor }) {
     if (this._isIntrayDayChart && this._quoteSummary && this._quoteSummary.PreviousClose) {
       const [minValueY, maxValueY] = this._chart.getYRange()
 

--- a/stocks@infinicode.de/components/settings/quoteStyleGroup.js
+++ b/stocks@infinicode.de/components/settings/quoteStyleGroup.js
@@ -1,0 +1,132 @@
+const { Adw, GObject, Gtk, Gdk } = imports.gi;
+
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+
+const { QuoteStyleSettings } = Me.imports.helpers.quoteStyleSettings;
+const { Translations } = Me.imports.helpers.translations;
+
+var QuoteStyleGroup = class QuoteStyleGroup extends Adw.PreferencesGroup {
+  static {
+    GObject.registerClass({ GTypeName: 'StockExtension-QuoteStyleGroup' }, this);
+  }
+
+  constructor() {
+    super({
+      title: Translations.SETTINGS.QUOTE_STYLE.GROUP_TITLE
+    });
+
+    const quoteStyleSettings = new QuoteStyleSettings();
+
+    this._addRow(new QuoteStylePostiveRow(quoteStyleSettings));
+    this._addRow(new QuoteStyleNegativeRow(quoteStyleSettings));
+  }
+
+  _addRow(quoteStyleRow) {
+    const actionRow = new Adw.ActionRow({
+      title: quoteStyleRow.ROW_TITLE
+    });
+
+    actionRow.add_suffix(this._getFontButton(quoteStyleRow));
+    actionRow.add_suffix(this._getColorButton(quoteStyleRow));
+
+    this.add(actionRow);
+  }
+
+  _getFontButton(quoteStyleRow) {
+    const fontButton = new Gtk.FontButton({
+      title: quoteStyleRow.FONT_CHOOSER
+    });
+
+    fontButton.set_font(quoteStyleRow.getFont());
+    fontButton.connect('font-set', (widget) => {
+      quoteStyleRow.setFont(fontButton.get_font());
+    });
+
+    return fontButton;
+  }
+
+  _getColorButton(quoteStyleRow) {
+    const colorButton = new Gtk.ColorButton({
+      title: quoteStyleRow.COLOR_CHOOSER
+    });
+
+    colorButton.connect('color-set', (widget) => {
+      quoteStyleRow.setQuoteColor(colorButton.get_rgba().to_string());
+    });
+
+    const rgba = new Gdk.RGBA();
+    rgba.parse(quoteStyleRow.getQuoteColor());
+    colorButton.rgba = rgba;
+
+    return colorButton;
+  }
+}
+
+class QuoteStyleRow {
+  ROW_TITLE = '';
+  FONT_CHOOSER = '';
+  COLOR_CHOOSER = '';
+
+  constructor(quoteStyleSettings) {
+    this._quoteStyleSettings = quoteStyleSettings;
+  }
+
+  getQuoteColor() { }
+  setQuoteColor(value) { }
+
+  getFont() { }
+  setFont(value) { }
+}
+
+class QuoteStylePostiveRow extends QuoteStyleRow {
+  ROW_TITLE = Translations.SETTINGS.QUOTE_STYLE.ROW_POSITIVE;
+  FONT_CHOOSER = Translations.SETTINGS.QUOTE_STYLE.FONT_CHOOSER_POSITIVE;
+  COLOR_CHOOSER = Translations.SETTINGS.QUOTE_STYLE.COLOR_CHOOSER_POSITIVE;
+
+  constructor(quoteStyleSettings) {
+    super(quoteStyleSettings);
+  }
+
+  getQuoteColor() {
+    return this._quoteStyleSettings.color_positive;
+  }
+
+  setQuoteColor(value) {
+    this._quoteStyleSettings.color_positive = value;
+  }
+
+  getFont() {
+    return this._quoteStyleSettings.font_positive;
+  }
+
+  setFont(value) {
+    this._quoteStyleSettings.font_positive = value;
+  }
+}
+
+class QuoteStyleNegativeRow extends QuoteStyleRow {
+  ROW_TITLE = Translations.SETTINGS.QUOTE_STYLE.ROW_NEGATIVE;
+  FONT_CHOOSER = Translations.SETTINGS.QUOTE_STYLE.FONT_CHOOSER_NEGATIVE;
+  COLOR_CHOOSER = Translations.SETTINGS.QUOTE_STYLE.COLOR_CHOOSER_NEGATIVE;
+
+  constructor(quoteStyleSettings) {
+    super(quoteStyleSettings);
+  }
+
+  getQuoteColor() {
+    return this._quoteStyleSettings.color_negative;
+  }
+
+  setQuoteColor(value) {
+    this._quoteStyleSettings.color_negative = value;
+  }
+
+  getFont() {
+    return this._quoteStyleSettings.font_negative;
+  }
+
+  setFont(value) {
+    this._quoteStyleSettings.font_negative = value;
+  }
+}

--- a/stocks@infinicode.de/components/settings/stylesPage.js
+++ b/stocks@infinicode.de/components/settings/stylesPage.js
@@ -1,0 +1,25 @@
+const ExtensionUtils = imports.misc.extensionUtils
+const Me = ExtensionUtils.getCurrentExtension()
+
+const { Adw, Gio, GObject, Gtk, Gdk } = imports.gi
+
+const { SettingsHandler } = Me.imports.helpers.settings
+const { Translations } = Me.imports.helpers.translations
+const { QuoteStyleGroup } = Me.imports.components.settings.quoteStyleGroup
+
+var StylesPage = GObject.registerClass(
+  {
+    GTypeName: 'StockExtension-StylesPage',
+  },
+  class StockStylesPreferencePage extends Adw.PreferencesPage {
+    _init() {
+      super._init({
+        title: Translations.SETTINGS.TITLE_STYLES,
+        icon_name: 'font-select-symbolic',
+        name: 'StylesPage'
+      });
+
+      this.add(new QuoteStyleGroup());
+    }
+  }
+)

--- a/stocks@infinicode.de/components/stocks/stockDetails.js
+++ b/stocks@infinicode.de/components/stocks/stockDetails.js
@@ -3,14 +3,15 @@ const { GObject, St } = imports.gi
 const ExtensionUtils = imports.misc.extensionUtils
 
 const Me = ExtensionUtils.getCurrentExtension()
-const { fallbackIfNaN, roundOrDefault, getStockColorStyleClass } = Me.imports.helpers.data
+const { fallbackIfNaN, roundOrDefault } = Me.imports.helpers.data
 const { Translations } = Me.imports.helpers.translations
 const { MARKET_STATES } = Me.imports.services.meta.generic
+const { getQuoteStyle } = Me.imports.helpers.styles
 
 var StockDetails = GObject.registerClass({
   GTypeName: 'StockExtension_StockDetails'
 }, class StockDetails extends St.BoxLayout {
-  _init ({ quoteSummary }) {
+  _init({ quoteSummary }) {
     super._init({
       style_class: 'stock-details',
       x_expand: true,
@@ -23,7 +24,7 @@ var StockDetails = GObject.registerClass({
     this.connect('destroy', this._onDestroy.bind(this))
   }
 
-  _sync ({ quoteSummary }) {
+  _sync({ quoteSummary }) {
     this._headerBox = this._createHeaderBox({ quoteSummary })
     this._detailsTableBox = this._createDetailBox({ quoteSummary })
 
@@ -31,7 +32,7 @@ var StockDetails = GObject.registerClass({
     this.add_child(this._detailsTableBox)
   }
 
-  _createHeaderBox ({ quoteSummary }) {
+  _createHeaderBox({ quoteSummary }) {
     const headerBox = new St.BoxLayout({
       style_class: 'header-box',
       x_expand: true,
@@ -57,7 +58,7 @@ var StockDetails = GObject.registerClass({
     return headerBox
   }
 
-  _createStockInfo ({ quoteSummary }) {
+  _createStockInfo({ quoteSummary }) {
     let stockInformationBox = new St.Bin({
       style_class: 'stock-information-box',
       x_expand: true,
@@ -71,8 +72,8 @@ var StockDetails = GObject.registerClass({
     return stockInformationBox
   }
 
-  _createQuoteInfo ({ quoteSummary }) {
-    const quoteColorStyleClass = getStockColorStyleClass(quoteSummary.Change)
+  _createQuoteInfo({ quoteSummary }) {
+    const quoteStyle = getQuoteStyle(quoteSummary.Change)
 
     const quoteInformationBox = new St.BoxLayout({
       style_class: 'quote-information-box tar',
@@ -81,19 +82,21 @@ var StockDetails = GObject.registerClass({
     })
 
     const regularQuoteLabel = new St.Label({
-      style_class: `quote-label ${quoteColorStyleClass}`,
+      style_class: `quote-label`,
+      style: quoteStyle,
       text: `${roundOrDefault(quoteSummary.Close)}${quoteSummary.CurrencySymbol ? ` ${quoteSummary.CurrencySymbol}` : ''}`
     })
 
     quoteInformationBox.add_child(regularQuoteLabel)
 
     if (quoteSummary.MarketState === MARKET_STATES.PRE) {
-      const preMarketQuoteColorStyleClass = getStockColorStyleClass(quoteSummary.PreMarketChange)
+      const preMarketQuoteStyle = getQuoteStyle(quoteSummary.PreMarketChange)
 
       quoteInformationBox.add_child(new St.Label({ style_class: 'quote-separation tar', text: ' / ' }))
 
       const preMarketQuoteLabel = new St.Label({
-        style_class: `quote-label pre-market ${preMarketQuoteColorStyleClass}`,
+        style_class: `quote-label pre-market`,
+        style: preMarketQuoteStyle,
         text: `${roundOrDefault(quoteSummary.PreMarketPrice)}${quoteSummary.CurrencySymbol ? ` ${quoteSummary.CurrencySymbol}` : ''}*`
       })
 
@@ -101,12 +104,13 @@ var StockDetails = GObject.registerClass({
     }
 
     if (quoteSummary.MarketState === MARKET_STATES.POST) {
-      const postMarketQuoteColorStyleClass = getStockColorStyleClass(quoteSummary.PostMarketChange)
+      const postMarketQuoteStyle = getQuoteStyle(quoteSummary.PostMarketChange)
 
       quoteInformationBox.add_child(new St.Label({ style_class: 'quote-separation tar', text: ' / ' }))
 
       const postMarketQuoteLabel = new St.Label({
-        style_class: `quote-label post-market ${postMarketQuoteColorStyleClass}`,
+        style_class: `quote-label post-market`,
+        style: postMarketQuoteStyle,
         text: `${roundOrDefault(quoteSummary.PostMarketPrice)}${quoteSummary.CurrencySymbol ? ` ${quoteSummary.CurrencySymbol}` : ''}*`
       })
 
@@ -116,7 +120,7 @@ var StockDetails = GObject.registerClass({
     return quoteInformationBox
   }
 
-  _createDetailBox ({ quoteSummary }) {
+  _createDetailBox({ quoteSummary }) {
     let detailBox = new St.BoxLayout({
       style_class: 'stock-details-box',
       x_expand: true,
@@ -129,7 +133,7 @@ var StockDetails = GObject.registerClass({
     return detailBox
   }
 
-  _createLeftDetailBox ({ quoteSummary }) {
+  _createLeftDetailBox({ quoteSummary }) {
     let leftDetailBox = new St.BoxLayout({
       style_class: 'stock-left-details-box',
       x_expand: true,
@@ -138,48 +142,48 @@ var StockDetails = GObject.registerClass({
     })
 
     leftDetailBox.add(this._createDetailItem(
-        this._createDetailItemLabel(Translations.STOCKS.SYMBOL),
-        this._createDetailItemValue(quoteSummary.Symbol)
+      this._createDetailItemLabel(Translations.STOCKS.SYMBOL),
+      this._createDetailItemValue(quoteSummary.Symbol)
     ))
 
     leftDetailBox.add(this._createDetailItem(
-        this._createDetailItemLabel(Translations.STOCKS.CHANGE),
-        this._createDetailItemValueForChange(quoteSummary.Change, quoteSummary.CurrencySymbol, quoteSummary.ChangePercent)
+      this._createDetailItemLabel(Translations.STOCKS.CHANGE),
+      this._createDetailItemValueForChange(quoteSummary.Change, quoteSummary.CurrencySymbol, quoteSummary.ChangePercent)
     ))
 
     if (quoteSummary.MarketState === MARKET_STATES.PRE) {
       leftDetailBox.add(this._createDetailItem(
-          this._createDetailItemLabel(Translations.STOCKS.CHANGE_PRE_MARKET),
-          this._createDetailItemValueForChange(quoteSummary.PreMarketChange, quoteSummary.CurrencySymbol, quoteSummary.PreMarketChangePercent)
+        this._createDetailItemLabel(Translations.STOCKS.CHANGE_PRE_MARKET),
+        this._createDetailItemValueForChange(quoteSummary.PreMarketChange, quoteSummary.CurrencySymbol, quoteSummary.PreMarketChangePercent)
       ))
     }
 
     if (quoteSummary.MarketState === MARKET_STATES.POST) {
       leftDetailBox.add(this._createDetailItem(
-          this._createDetailItemLabel(Translations.STOCKS.CHANGE_POST_MARKET),
-          this._createDetailItemValueForChange(quoteSummary.PostMarketChange, quoteSummary.CurrencySymbol, quoteSummary.PostMarketChangePercent)
+        this._createDetailItemLabel(Translations.STOCKS.CHANGE_POST_MARKET),
+        this._createDetailItemValueForChange(quoteSummary.PostMarketChange, quoteSummary.CurrencySymbol, quoteSummary.PostMarketChangePercent)
       ))
     }
 
     leftDetailBox.add(this._createDetailItem(
-        this._createDetailItemLabel(Translations.STOCKS.OPEN),
-        this._createDetailItemValue(roundOrDefault(quoteSummary.Open))
+      this._createDetailItemLabel(Translations.STOCKS.OPEN),
+      this._createDetailItemValue(roundOrDefault(quoteSummary.Open))
     ))
 
     leftDetailBox.add(this._createDetailItem(
-        this._createDetailItemLabel(Translations.STOCKS.HIGH),
-        this._createDetailItemValue(roundOrDefault(quoteSummary.High))
+      this._createDetailItemLabel(Translations.STOCKS.HIGH),
+      this._createDetailItemValue(roundOrDefault(quoteSummary.High))
     ))
 
     leftDetailBox.add(this._createDetailItem(
-        this._createDetailItemLabel(Translations.STOCKS.TIME),
-        this._createDetailItemValue((new Date(quoteSummary.Timestamp)).toLocaleFormat(Translations.FORMATS.DEFAULT_DATE_TIME))
+      this._createDetailItemLabel(Translations.STOCKS.TIME),
+      this._createDetailItemValue((new Date(quoteSummary.Timestamp)).toLocaleFormat(Translations.FORMATS.DEFAULT_DATE_TIME))
     ))
 
     return leftDetailBox
   }
 
-  _createRightDetailBox ({ quoteSummary }) {
+  _createRightDetailBox({ quoteSummary }) {
     let rightDetailBox = new St.BoxLayout({
       style_class: 'stock-details-box',
       x_expand: true,
@@ -188,48 +192,48 @@ var StockDetails = GObject.registerClass({
     })
 
     rightDetailBox.add(this._createDetailItem(
-        this._createDetailItemLabel(Translations.STOCKS.EXCHANGE),
-        this._createDetailItemValue(quoteSummary.ExchangeName || Translations.UNKNOWN)
+      this._createDetailItemLabel(Translations.STOCKS.EXCHANGE),
+      this._createDetailItemValue(quoteSummary.ExchangeName || Translations.UNKNOWN)
     ))
 
     rightDetailBox.add(this._createDetailItem(
-        this._createDetailItemLabel(Translations.STOCKS.PREVIOUS_CLOSE),
-        this._createDetailItemValue(roundOrDefault(quoteSummary.PreviousClose))
+      this._createDetailItemLabel(Translations.STOCKS.PREVIOUS_CLOSE),
+      this._createDetailItemValue(roundOrDefault(quoteSummary.PreviousClose))
     ))
 
     if (quoteSummary.MarketState === MARKET_STATES.PRE) {
       rightDetailBox.add(this._createDetailItem(
-          this._createDetailItemLabel(Translations.STOCKS.TIME_PRE_MARKET),
-          this._createDetailItemValue((new Date(quoteSummary.PreMarketTimestamp)).toLocaleFormat(Translations.FORMATS.DEFAULT_DATE_TIME))
+        this._createDetailItemLabel(Translations.STOCKS.TIME_PRE_MARKET),
+        this._createDetailItemValue((new Date(quoteSummary.PreMarketTimestamp)).toLocaleFormat(Translations.FORMATS.DEFAULT_DATE_TIME))
       ))
     }
 
     if (quoteSummary.MarketState === MARKET_STATES.POST) {
       rightDetailBox.add(this._createDetailItem(
-          this._createDetailItemLabel(Translations.STOCKS.TIME_POST_MARKET),
-          this._createDetailItemValue((new Date(quoteSummary.PostMarketTimestamp)).toLocaleFormat(Translations.FORMATS.DEFAULT_DATE_TIME))
+        this._createDetailItemLabel(Translations.STOCKS.TIME_POST_MARKET),
+        this._createDetailItemValue((new Date(quoteSummary.PostMarketTimestamp)).toLocaleFormat(Translations.FORMATS.DEFAULT_DATE_TIME))
       ))
     }
 
     rightDetailBox.add(this._createDetailItem(
-        this._createDetailItemLabel(Translations.STOCKS.CLOSE),
-        this._createDetailItemValue(roundOrDefault(quoteSummary.Close))
+      this._createDetailItemLabel(Translations.STOCKS.CLOSE),
+      this._createDetailItemValue(roundOrDefault(quoteSummary.Close))
     ))
 
     rightDetailBox.add(this._createDetailItem(
-        this._createDetailItemLabel(Translations.STOCKS.LOW),
-        this._createDetailItemValue(roundOrDefault(quoteSummary.Low))
+      this._createDetailItemLabel(Translations.STOCKS.LOW),
+      this._createDetailItemValue(roundOrDefault(quoteSummary.Low))
     ))
 
     rightDetailBox.add(this._createDetailItem(
-        this._createDetailItemLabel(Translations.STOCKS.VOLUME),
-        this._createDetailItemValue(fallbackIfNaN(quoteSummary.Volume))
+      this._createDetailItemLabel(Translations.STOCKS.VOLUME),
+      this._createDetailItemValue(fallbackIfNaN(quoteSummary.Volume))
     ))
 
     return rightDetailBox
   }
 
-  _createDetailItem (label, value) {
+  _createDetailItem(label, value) {
     const detailItem = new St.BoxLayout({
       style_class: 'detail-item-bin',
       x_expand: true,
@@ -242,7 +246,7 @@ var StockDetails = GObject.registerClass({
     return detailItem
   }
 
-  _createDetailItemLabel (text) {
+  _createDetailItemLabel(text) {
     const detailItemLabel = new St.Bin({
       style_class: 'detail-item-label-bin',
       x_expand: true,
@@ -253,7 +257,7 @@ var StockDetails = GObject.registerClass({
     return detailItemLabel
   }
 
-  _createDetailItemValue (text, additionalStyleClass) {
+  _createDetailItemValue(text, additionalStyleClass) {
     const detailItemValue = new St.Bin({
       style_class: 'detail-item-value-bin',
       x_expand: true,
@@ -264,7 +268,7 @@ var StockDetails = GObject.registerClass({
     return detailItemValue
   }
 
-  _createDetailItemValueForChange (change, currency, changePercent) {
+  _createDetailItemValueForChange(change, currency, changePercent) {
     const detailItem = new St.BoxLayout({
       style_class: 'detail-item-value-box change',
       x_expand: false,
@@ -272,19 +276,27 @@ var StockDetails = GObject.registerClass({
       x_align: St.Align.END
     })
 
-    const quoteColorStyleClass = getStockColorStyleClass(change)
+    const quoteStyle = getQuoteStyle(change)
 
-    const changeLabel = new St.Label({ style_class: `detail-item-value change tar ${quoteColorStyleClass}`, text: `${roundOrDefault(change)}${currency ? ` ${currency}` : ''}` })
+    const changeLabel = new St.Label({
+      style_class: `detail-item-value change tar`,
+      style: quoteStyle,
+      text: `${roundOrDefault(change)}${currency ? ` ${currency}` : ''}`
+    })
     detailItem.add_child(changeLabel)
 
     detailItem.add_child(new St.Label({ style_class: 'detail-item-value tar', text: ' / ' }))
 
-    const changePercentLabel = new St.Label({ style_class: `detail-item-value change tar ${quoteColorStyleClass}`, text: `${roundOrDefault(changePercent)} %` })
+    const changePercentLabel = new St.Label({
+      style_class: `detail-item-value change tar`,
+      style: quoteStyle,
+      text: `${roundOrDefault(changePercent)} %`
+    })
     detailItem.add_child(changePercentLabel)
 
     return detailItem
   }
 
-  _onDestroy () {
+  _onDestroy() {
   }
 })

--- a/stocks@infinicode.de/helpers/data.js
+++ b/stocks@infinicode.de/helpers/data.js
@@ -53,20 +53,6 @@ var cacheOrDefault = async (cacheKey, evaluator, cacheDuration = CACHE_TIME) => 
   return freshData
 }
 
-var getStockColorStyleClass = change => {
-  let quoteColorStyleClass = 'quote-neutral'
-
-  if (change) {
-    if (change > 0.00) {
-      quoteColorStyleClass = 'quote-positive'
-    } else if (change < 0.00) {
-      quoteColorStyleClass = 'quote-negative'
-    }
-  }
-
-  return quoteColorStyleClass
-}
-
 var getComplementaryColor = (hex, bw = true) => {
   const padZero = (str, len) => {
     len = len || 2

--- a/stocks@infinicode.de/helpers/fetch.js
+++ b/stocks@infinicode.de/helpers/fetch.js
@@ -10,7 +10,7 @@ const Response = class {
 
     if (message) {
       this.headers = message.response_headers
-      this.url = message.get_uri().to_string()
+      this.url = message.get_uri().to_string(true)
       this.status = message.status_code
       this.statusText = Soup.Status.get_phrase(this.status)
 

--- a/stocks@infinicode.de/helpers/quoteStyleSettings.js
+++ b/stocks@infinicode.de/helpers/quoteStyleSettings.js
@@ -1,0 +1,45 @@
+const ExtensionUtils = imports.misc.extensionUtils
+const Me = ExtensionUtils.getCurrentExtension()
+
+var QUOTE_STYLE_COLOR_POSITIVE = 'quote-style-color-positive';
+var QUOTE_STYLE_COLOR_NEGATIVE = 'quote-style-color-negative';
+var QUOTE_STYLE_FONT_POSITIVE = 'quote-style-font-positive';
+var QUOTE_STYLE_FONT_NEGATIVE = 'quote-style-font-negative';
+
+var QuoteStyleSettings = class QuoteStyleSettings {
+  constructor() {
+    this._settings = ExtensionUtils.getSettings();
+  }
+
+  get color_positive() {
+    return this._settings.get_string(QUOTE_STYLE_COLOR_POSITIVE);
+  }
+
+  set color_positive(value) {
+    return this._settings.set_string(QUOTE_STYLE_COLOR_POSITIVE, value);
+  }
+
+  get color_negative() {
+    return this._settings.get_string(QUOTE_STYLE_COLOR_NEGATIVE);
+  }
+
+  set color_negative(value) {
+    return this._settings.set_string(QUOTE_STYLE_COLOR_NEGATIVE, value);
+  }
+
+  get font_positive() {
+    return this._settings.get_string(QUOTE_STYLE_FONT_POSITIVE);
+  }
+
+  set font_positive(value) {
+    return this._settings.set_string(QUOTE_STYLE_FONT_POSITIVE, value);
+  }
+
+  get font_negative() {
+    return this._settings.get_string(QUOTE_STYLE_FONT_NEGATIVE);
+  }
+
+  set font_negative(value) {
+    return this._settings.set_string(QUOTE_STYLE_FONT_NEGATIVE, value);
+  }
+}

--- a/stocks@infinicode.de/helpers/styles.js
+++ b/stocks@infinicode.de/helpers/styles.js
@@ -1,0 +1,41 @@
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+const { QuoteStyleSettings } = Me.imports.helpers.quoteStyleSettings;
+
+var getQuoteStyle = change => {
+  const quoteStyle = [];
+
+  if (change) {
+    try {
+      const quoteStyleSettings = new QuoteStyleSettings();
+
+      if (change > 0) {
+        if (quoteStyleSettings.color_positive !== '') {
+          quoteStyle.push(`color: ${quoteStyleSettings.color_positive};`);
+        }
+        if (quoteStyleSettings.font_positive !== '') {
+          const font = quoteStyleSettings.font_positive.split(' ');
+          const fontFamily = font.slice(0, -1).join(' ');
+          const fontSize = font[font.length - 1];
+          quoteStyle.push(`font-family: "${fontFamily}";`);
+          quoteStyle.push(`font-size: ${fontSize}px;`);
+        }
+      } else if (change < 0) {
+        if (quoteStyleSettings.color_negative !== '') {
+          quoteStyle.push(`color: ${quoteStyleSettings.color_negative};`);
+        }
+        if (quoteStyleSettings.font_negative !== '') {
+          const font = quoteStyleSettings.font_negative.split(' ');
+          const fontFamily = font.slice(0, -1).join(' ');
+          const fontSize = font[font.length - 1];
+          quoteStyle.push(`font-family: "${fontFamily}";`);
+          quoteStyle.push(`font-size: ${fontSize}px;`);
+        }
+      }
+    } catch (e) {
+      log('colors.js: getQuoteStyle: failed', e);
+    }
+  }
+
+  return quoteStyle.join('');
+}

--- a/stocks@infinicode.de/helpers/translations.js
+++ b/stocks@infinicode.de/helpers/translations.js
@@ -27,6 +27,7 @@ var Translations = {
     REMOVE_CONFIRMATION_TEXT: _('Remove %s?'),
     TITLE_GENERAL: _('General'),
     TITLE_SETTINGS: _('Settings'),
+    TITLE_STYLES: _('Styles'),
     TITLE_ABOUT: _('About'),
     TITLE_SYMBOLS: _('Symbols'),
     TITLE_SYMBOLS_LIST: _('Symbol List'),
@@ -44,7 +45,16 @@ var Translations = {
     TICKER_STOCK_AMOUNT_LABEL: _('Items to show in ticker'),
     TICKER_INTERVAL_LABEL: _('Stock Panel Ticker Interval in Seconds'),
     SHOW_TICKER_OFF_MARKET_PRICES_LABEL: _('Show off-market prices in Ticker'),
-    USE_NAMES_FROM_PROVIDER_LABEL: _('Use instrument names from provider')
+    USE_NAMES_FROM_PROVIDER_LABEL: _('Use instrument names from provider'),
+    QUOTE_STYLE: {
+      GROUP_TITLE: _('Quote styles'),
+      ROW_POSITIVE: _('Positive'),
+      ROW_NEGATIVE: _('Negative'),
+      COLOR_CHOOSER_POSITIVE: _('Quote positive color'),
+      COLOR_CHOOSER_NEGATIVE: _('Quote negative color'),
+      FONT_CHOOSER_POSITIVE: _('Quote positive font'),
+      FONT_CHOOSER_NEGATIVE: _('Quote negative font'),
+    }
   },
   STOCKS: {
     SYMBOL: _('Symbol'),

--- a/stocks@infinicode.de/metadata.json
+++ b/stocks@infinicode.de/metadata.json
@@ -10,5 +10,5 @@
   ],
   "url": "https://github.com/cinatic/stocks-extension",
   "uuid": "stocks@infinicode.de",
-  "version": 25
+  "version": 26
 }

--- a/stocks@infinicode.de/prefs.js
+++ b/stocks@infinicode.de/prefs.js
@@ -6,12 +6,13 @@ const Me = ExtensionUtils.getCurrentExtension()
 const { AboutPage } = Me.imports.components.settings.aboutPage
 const { SymbolsListPage } = Me.imports.components.settings.symbolsListPage
 const { SettingsPage } = Me.imports.components.settings.settingsPage
+const { StylesPage } = Me.imports.components.settings.stylesPage
 
-function init () {
+function init() {
   ExtensionUtils.initTranslations()
 }
 
-function fillPreferencesWindow (window) {
+function fillPreferencesWindow(window) {
   let iconTheme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
   if (!iconTheme.get_search_path().includes(Me.path + '/media')) {
     iconTheme.add_search_path(Me.path + '/media')
@@ -24,6 +25,9 @@ function fillPreferencesWindow (window) {
 
   const settingsPage = new SettingsPage()
   window.add(settingsPage)
+
+  const stylesPage = new StylesPage()
+  window.add(stylesPage)
 
   const aboutPage = new AboutPage()
   window.add(aboutPage)

--- a/stocks@infinicode.de/schemas/org.gnome.shell.extensions.stock.gschema.xml
+++ b/stocks@infinicode.de/schemas/org.gnome.shell.extensions.stock.gschema.xml
@@ -28,6 +28,22 @@
             <default>'Xetra Alibaba-§§-AHLA.DE'</default>
             <summary>old version stock symbol definition (do not use anymore, but keep for migration))</summary>
         </key>
+        <key type="s" name="quote-style-color-positive">
+            <default>'rgb(0,135,60)'</default>
+            <summary>Quote color positive</summary>
+        </key>
+        <key type="s" name="quote-style-color-negative">
+            <default>'rgb(244,78,63)'</default>
+            <summary>Quote color negative</summary>
+        </key>
+        <key type="s" name="quote-style-font-positive">
+            <default>'System-ui 11px'</default>
+            <summary>Quote font positive</summary>
+        </key>
+        <key type="s" name="quote-style-font-negative">
+            <default>'System-ui 11px'</default>
+            <summary>Quote font negative</summary>
+        </key>
         <key type="s" name="symbol-current-quotes">
             <default>''</default>
             <summary>JSON representation of symbol data</summary>

--- a/stocks@infinicode.de/stylesheet.css
+++ b/stocks@infinicode.de/stylesheet.css
@@ -15,16 +15,6 @@
     text-align: right;
 }
 
-.stocks-extension .quote-positive {
-    color: #00873c;
-    font-weight: bolder;
-}
-
-.stocks-extension .quote-negative {
-    color: #F44E3F;
-    font-weight: bolder;
-}
-
 .button-group .button {
     margin: 0 5px;
 }


### PR DESCRIPTION
Hi @cinatic !

I needed to change the quote colours (especially in `menuStockTicker`, but I've covered all other places).
- `QuoteStyleSettings` is responsible for the font and colour
- a new page in the extension settings `Styles`
- `getStockColorStyleClass` was replaced with `getQuoteStyle`

I was thinking about moving the first three settings from `Settings` to that new page `Styles` as they are relative, but I decided not to touch existing features.

Please let me know if I overlooked something, as it was my first experience with Gnome Shell Extensions :)

PS. This PR will also be a proper fix for the https://github.com/cinatic/stocks-extension/issues/62 and https://github.com/cinatic/stocks-extension/issues/45 issues.

## Screenshots
### Styles settings page
![image](https://user-images.githubusercontent.com/12776808/209465333-718d7e5e-f396-4f5e-99ff-9669767eda43.png)

### Overview
![image](https://user-images.githubusercontent.com/12776808/209465352-39e03c89-6cd1-4ba0-a302-79a7d752b6e5.png)

### Details positive
![image](https://user-images.githubusercontent.com/12776808/209465355-7a0525d1-4821-448d-b0b9-2b244adb9002.png)

### Details negative
![image](https://user-images.githubusercontent.com/12776808/209465360-059d09c2-cf47-4f63-9929-4e71fefbc9f6.png)

### Compact
![image](https://user-images.githubusercontent.com/12776808/209465371-c5856cdc-6dcc-4bc0-ab38-187c3861fcfa.png)

### Regular
![image](https://user-images.githubusercontent.com/12776808/209465377-ed1fa5df-a842-4753-bf9d-4ce83709c4e3.png)

## Tremendous
![image](https://user-images.githubusercontent.com/12776808/209465411-175e96dd-f619-459c-8bed-adb95929fa37.png)

### Minimal
![image](https://user-images.githubusercontent.com/12776808/209465402-9c61e3f2-f781-4695-954d-7163293d7a6e.png)

