### PR TITLE
Gnome 49, fix Yahoo, minimum refresh 5m

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_build
+.idea
+/stocks@infinicode.de/schemas/gschemas.compiled
+/stocks@infinicode.de/locale

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ CSS_FILES := $(wildcard $(SRC_DIR)/*.css)
 MEDIA_FILES := $(wildcard $(SRC_DIR)/media)
 JS_COMPONENTS := $(SRC_DIR)/components $(SRC_DIR)/helpers $(SRC_DIR)/services
 
+SCHEMA_FILES := $(wildcard $(SCHEMAS_DIR)/*.gschema.xml)
 COMPILED_SCHEMAS := $(SCHEMAS_DIR)/gschemas.compiled
 
 POT_FILE := $(PO_DIR)/$(UUID).pot
@@ -45,7 +46,7 @@ default: build
 $(BUILD_DIR):
 	mkdir -p $@
 
-$(COMPILED_SCHEMAS):
+$(COMPILED_SCHEMAS): $(SCHEMA_FILES)
 	glib-compile-schemas $(SCHEMAS_DIR)
 
 $(LOCALE_DIR)/%/LC_MESSAGES:

--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ To add stocks you need the provider related symbol / identifier. You should be a
 
 
 ### debug
-dbus-run-session -- gnome-shell --nested --wayland
+dbus-run-session -- gnome-shell --devkit --wayland

--- a/stocks@infinicode.de/components/chart/chart.js
+++ b/stocks@infinicode.de/components/chart/chart.js
@@ -47,6 +47,11 @@ export const Chart = GObject.registerClass({
       return
     }
 
+    // Check if the actor has been allocated before trying to draw
+    if (!this.get_stage() || this.get_width() === 0 || this.get_height() === 0) {
+      return
+    }
+
     const cairoContext = this.get_context()
     const [width, height] = this.get_surface_size()
 
@@ -228,6 +233,11 @@ export const Chart = GObject.registerClass({
       return
     }
 
+    // Check if the actor has been allocated before getting position
+    if (!this.get_stage() || this.get_width() === 0 || this.get_height() === 0) {
+      return
+    }
+
     // first get position then
     // check if there is an open userline otherwise open one
 
@@ -254,6 +264,11 @@ export const Chart = GObject.registerClass({
 
   _onHover (item, event) {
     if (isNullOrEmpty(this.data)) {
+      return
+    }
+
+    // Check if the actor has been allocated before getting position
+    if (!this.get_stage() || this.get_width() === 0 || this.get_height() === 0) {
       return
     }
 

--- a/stocks@infinicode.de/components/screens/stockDetailsScreen/stockDetailsScreen.js
+++ b/stocks@infinicode.de/components/screens/stockDetailsScreen/stockDetailsScreen.js
@@ -155,7 +155,6 @@ export const StockDetailsScreen = GObject.registerClass({
     this.add_child(stockDetailsTabButtonGroup)
     this.add_child(stockDetails)
 
-    // FIXME: adding chart throws a lot of "Can't update stage views actor", no clue what is going on here
     this.add_child(chartRangeButtonGroup)
     this.add_child(this._chart)
     this.add_child(chartValueHoverBox)

--- a/stocks@infinicode.de/components/screens/stockOverviewScreen/stockOverviewScreen.js
+++ b/stocks@infinicode.de/components/screens/stockOverviewScreen/stockOverviewScreen.js
@@ -124,7 +124,7 @@ export const StockOverviewScreen = GObject.registerClass({
   _registerTimeout () {
     this._autoRefreshTimeoutId = setInterval(() => {
       this._loadData()
-    }, (this._settings.ticker_interval || 10) * 1000)
+    }, (this._settings.refresh_interval || 15) * 60 * 1000)
   }
 
   async _loadData () {

--- a/stocks@infinicode.de/components/settings/settingsPage.js
+++ b/stocks@infinicode.de/components/settings/settingsPage.js
@@ -114,6 +114,33 @@ class GeneralPreferenceGroup extends Adw.PreferencesGroup {
     tickerIntervalRow.add_suffix(tickerIntervalSpinButton)
     this.add(tickerIntervalRow)
 
+    const refreshIntervalSpinButton = new Gtk.SpinButton({
+      adjustment: new Gtk.Adjustment({
+        // Displayed in MINUTES; enforce minimum of 5 minutes in UI
+        lower: 5, upper: 1440, step_increment: 1, page_increment: 5, page_size: 0,
+      }),
+      climb_rate: 1,
+      digits: 0,
+      numeric: true,
+      valign: Gtk.Align.CENTER,
+    })
+
+    // Settings are stored in MINUTES
+    refreshIntervalSpinButton.set_value(this._settings.refresh_interval || 15)
+
+    refreshIntervalSpinButton.connect('value-changed', (widget) => {
+      // Persist in MINUTES
+      this._settings.refresh_interval = widget.get_value()
+    })
+
+    const refreshIntervalRow = new Adw.ActionRow({
+      title: Translations.SETTINGS.REFRESH_INTERVAL_LABEL,
+      activatable_widget: refreshIntervalSpinButton
+    })
+
+    refreshIntervalRow.add_suffix(refreshIntervalSpinButton)
+    this.add(refreshIntervalRow)
+
     const showTickerOffMarketPricesSwitch = new Gtk.Switch({
       valign: Gtk.Align.CENTER
     })

--- a/stocks@infinicode.de/helpers/fetch.js
+++ b/stocks@infinicode.de/helpers/fetch.js
@@ -1,7 +1,7 @@
 import Soup from 'gi://Soup'
 
 const DEFAULT_TIME_OUT_IN_SECONDS = 10
-const DEFAULT_CHROME_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
+const DEFAULT_CHROME_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
 
 const Response = class {
   constructor (message, body) {
@@ -76,6 +76,9 @@ export const fetch = ({ url, method = 'GET', headers, queryParameters, customHtt
 
     const request_message = Soup.Message.new(method, url)
 
+    // Always force the User-Agent header
+    request_message.request_headers.append('User-Agent', DEFAULT_CHROME_USER_AGENT)
+
     if (headers) {
       appendHeaders(request_message, headers)
     }
@@ -85,7 +88,6 @@ export const fetch = ({ url, method = 'GET', headers, queryParameters, customHtt
     }
 
     const httpSession = customHttpSession || new Soup.Session({
-      user_agent: DEFAULT_CHROME_USER_AGENT,
       timeout: DEFAULT_TIME_OUT_IN_SECONDS
     })
 

--- a/stocks@infinicode.de/helpers/settings.js
+++ b/stocks@infinicode.de/helpers/settings.js
@@ -16,6 +16,7 @@ export const STOCKS_SYMBOL_PAIRS = 'symbol-pairs'
 export const STOCKS_PORTFOLIOS = 'portfolios'
 export const STOCKS_TRANSACTIONS = 'transactions'
 export const STOCKS_TICKER_INTERVAL = 'ticker-interval'
+export const STOCKS_REFRESH_INTERVAL = 'refresh-interval'
 export const STOCKS_SHOW_OFF_MARKET_TICKER_PRICES = 'show-ticker-off-market-prices'
 export const STOCKS_TICKER_STOCK_AMOUNT = 'ticker-stock-amount'
 export const STOCKS_SELECTED_PORTFOLIO = 'selected-portfolio'
@@ -98,6 +99,20 @@ export const SettingsHandler = class SettingsHandler {
 
   set ticker_interval (value) {
     return this._settings.set_int(STOCKS_TICKER_INTERVAL, value)
+  }
+
+  get refresh_interval () {
+    const valueInMinutes = this._settings.get_int(STOCKS_REFRESH_INTERVAL)
+    if (isNullOrUndefined(valueInMinutes) || valueInMinutes < 5) {
+      // Reset to default of 15m to avoid hammering providers
+      this._settings.set_int(STOCKS_REFRESH_INTERVAL, 15)
+      return 15
+    }
+    return valueInMinutes
+  }
+
+  set refresh_interval (value) {
+    return this._settings.set_int(STOCKS_REFRESH_INTERVAL, value)
   }
 
   get ticker_stock_amount () {

--- a/stocks@infinicode.de/helpers/translations.js
+++ b/stocks@infinicode.de/helpers/translations.js
@@ -56,6 +56,7 @@ export const initTranslations = (_) => {
       },
       TICKER_STOCK_AMOUNT_LABEL: _('Items to show in ticker'),
       TICKER_INTERVAL_LABEL: _('Stock Panel Ticker Interval in Seconds'),
+      REFRESH_INTERVAL_LABEL: _('Data Refresh Interval in Minutes'),
       SHOW_TICKER_OFF_MARKET_PRICES_LABEL: _('Show off-market prices in Ticker'),
       USE_NAMES_FROM_PROVIDER_LABEL: _('Use instrument names from provider')
     },

--- a/stocks@infinicode.de/metadata.json
+++ b/stocks@infinicode.de/metadata.json
@@ -8,7 +8,8 @@
   "shell-version": [
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/cinatic/stocks-extension",
   "uuid": "stocks@infinicode.de",

--- a/stocks@infinicode.de/schemas/org.gnome.shell.extensions.stock.gschema.xml
+++ b/stocks@infinicode.de/schemas/org.gnome.shell.extensions.stock.gschema.xml
@@ -44,6 +44,10 @@
             <default>10</default>
             <summary>Ticker Interval in Seconds</summary>
         </key>
+        <key type="i" name="refresh-interval">
+            <default>15</default>
+            <summary>Data Refresh Interval in Minutes</summary>
+        </key>
         <key type="i" name="ticker-stock-amount">
             <default>1</default>
             <summary>Amount of Stocks to show simultaneously in Ticker</summary>


### PR DESCRIPTION
Fixes #120 

- Changed User Agent - it was definitely blocked
- Changed how headers were set, I don't think it worked consistently
- Separate data refresh interval, with a minimum of 5 minutes to avoid slamming Yahoo.
- Don't cache 429s as valid crumbs
- Drop crumb caching to 30 days
- Obviously invalid crumb sets expiration to 0 and skips that round of queries
- Fix misc GJS errors.